### PR TITLE
Basic Query Support

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: ruby
+
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2
+  - 2.3.0
+  - jruby
+
+sudo: false
+
+env:
+  - PURE_RUBY=1
+  - KITCHEN_SINK=1
+
+script: bundle exec rake
+
+bundler_args: --without docs release repl
+
+matrix:
+  exclude:
+    - rvm: jruby
+      env: KITCHEN_SINK=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,6 @@ rvm:
 
 sudo: false
 
-env:
-  - PURE_RUBY=1
-  - KITCHEN_SINK=1
-
 script: bundle exec rake
 
 bundler_args: --without docs release repl
-
-matrix:
-  exclude:
-    - rvm: jruby
-      env: KITCHEN_SINK=1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aws::Record
 
-[![Build Status](https://travis-ci.org/awslabs/aws-sdk-ruby-record.png?branch=master)](https://travis-ci.org/awslabs/aws-sdk-ruby-record) [![Code Climate](https://codeclimate.com/github/awslabs/aws-sdk-ruby-record.png)](https://codeclimate.com/github/awslabs/aws-sdk-ruby-record) [![Coverage Status](https://coveralls.io/repos/awslabs/aws-sdk-ruby-record/badge.svg?branch=master)](https://coveralls.io/r/awslabs/aws-sdk-ruby-record?branch=master)
+[![Build Status](https://travis-ci.org/awslabs/aws-sdk-ruby-record.png?branch=master)](https://travis-ci.org/awslabs/aws-sdk-ruby-record) [![Code Climate](https://codeclimate.com/github/awslabs/aws-sdk-ruby-record.png)](https://codeclimate.com/github/awslabs/aws-sdk-ruby-record)
 
 A data mapping abstraction over the AWS SDK for Ruby's client for Amazon
 DynamoDB.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Aws::Record
 
+[![Build Status](https://travis-ci.org/awslabs/aws-sdk-ruby-record.png?branch=master)](https://travis-ci.org/awslabs/aws-sdk-ruby-record) [![Code Climate](https://codeclimate.com/github/awslabs/aws-sdk-ruby-record.png)](https://codeclimate.com/github/awslabs/aws-sdk-ruby-record) [![Coverage Status](https://coveralls.io/repos/awslabs/aws-sdk-ruby-record/badge.svg?branch=master)](https://coveralls.io/r/awslabs/aws-sdk-ruby-record?branch=master)
+
 A data mapping abstraction over the AWS SDK for Ruby's client for Amazon
 DynamoDB.
 

--- a/features/items.feature
+++ b/features/items.feature
@@ -12,7 +12,7 @@
 # and limitations under the License.
 
 # language: en
-@item
+@dynamodb @item
 Feature: Amazon DynamoDB Items
   This feature tests the integration of model classes that include the
   Aws::Record module with a DynamoDB backend. To run these tests, you will need

--- a/features/search.feature
+++ b/features/search.feature
@@ -1,0 +1,132 @@
+# Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+# language: en
+@dynamodb @search
+Feature: Amazon DynamoDB Querying and Scanning
+  This feature tests integration of the client #query and #scan methods with the
+  Aws::Record abstraction.  To run these tests, you will need to have valid AWS
+  credentials that are accessible with the AWS SDK for Ruby's standard
+  credential provider chain. In practice, this means a shared credential file or
+  environment variables with your credentials. These tests may have some AWS
+  costs associated with running them since AWS resources are created and
+  destroyed within these tests.
+
+  Background:
+    Given a DynamoDB table named 'example' with data:
+      """
+      [
+        { "attribute_name": "id", "attribute_type": "S", "key_type": "HASH" },
+        { "attribute_name": "count", "attribute_type": "N", "key_type": "RANGE" }
+      ]
+      """
+    And an aws-record model with data:
+      """
+      [
+        { "method": "string_attr", "name": "id", "hash_key": true },
+        { "method": "integer_attr", "name": "count", "range_key": true },
+        { "method": "string_attr", "name": "body", "database_name": "content" }
+      ]
+      """
+    And an item exists in the DynamoDB table with item data:
+      """
+      {
+        "id": "1",
+        "count": 5,
+        "content": "First item."
+      }
+      """
+    And an item exists in the DynamoDB table with item data:
+      """
+      {
+        "id": "1",
+        "count": 10,
+        "content": "Second item."
+      }
+      """
+    And an item exists in the DynamoDB table with item data:
+      """
+      {
+        "id": "1",
+        "count": 15,
+        "content": "Third item."
+      }
+      """
+    And an item exists in the DynamoDB table with item data:
+      """
+      {
+        "id": "2",
+        "count": 10,
+        "content": "Fourth item."
+      }
+      """
+
+  Scenario: Run Query Directly From Aws::DynamoDB::Client#query
+    When we call the 'query' class method with parameter data:
+      """
+      {
+        "key_conditions": {
+          "id": {
+            "attribute_value_list": ["1"],
+            "comparison_operator": "EQ"
+          },
+          "count": {
+            "attribute_value_list": [7],
+            "comparison_operator": "GT"
+          }
+        }
+      }
+      """
+    Then we should receive an aws-record collection with members:
+      """
+      [
+        {
+          "id": "1",
+          "count": 10,
+          "content": "Second item."
+        },
+        {
+          "id": "1",
+          "count": 15,
+          "content": "Third item."
+        }
+      ]
+      """
+
+  Scenario: Run Scan Directly From Aws::DynamoDB::Client#scan
+    When we call the 'scan' class method
+    Then we should receive an aws-record collection with members:
+      """
+      [
+        {
+          "id": "1",
+          "count": 5,
+          "content": "First item."
+        },
+        {
+          "id": "1",
+          "count": 10,
+          "content": "Second item."
+        },
+        {
+          "id": "1",
+          "count": 15,
+          "content": "Third item."
+        },
+        {
+          "id": "2",
+          "count": 10,
+          "content": "Fourth item."
+        }
+      ]
+      """

--- a/features/secondary_indexes.feature
+++ b/features/secondary_indexes.feature
@@ -1,0 +1,66 @@
+# Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+# language: en
+@dynamodb @table @secondary_indexes
+Feature: Amazon DynamoDB Secondary Indexes
+  This feature tests the integration of model classes which define global
+  secondary indexes and/or local secondary indexes in DynamoDB. Indexes are
+  defined in your Aws::Record model, and are applied with the
+  Aws::Record::TableMigration class. To run these tests, you will need to
+  have valid AWS credentials that are accessible with the AWS SDK for Ruby's
+  standard credential provider chain. In practice, this means a shared
+  credential file or environment variables with your credentials. These tests
+  may have some AWS costs associated with running them since AWS resources are
+  created and destroyed within these tests.
+
+  Background:
+    Given an aws-record model with definition:
+      """
+      integer_attr :forum_id, hash_key: true
+      integer_attr :post_id, range_key: true
+      string_attr  :forum_name
+      string_attr  :post_title
+      string_attr  :post_body
+      integer_attr :author_id
+      string_attr  :author_name
+      """
+
+  Scenario: Create a DynamoDB Table with a Local Secondary Index
+    When we add a local secondary index to the model with parameters:
+      """
+      [
+        "title",
+        {
+          "range_key": "post_title",
+          "projection": {
+            "projection_type": "INCLUDE",
+            "non_key_attributes": [
+              "post_body"
+            ]
+          }
+        }
+      ]
+      """
+    And we create a table migration for the model
+    And we call 'create!' with parameters:
+      """
+      {
+        "provisioned_throughput": {
+          "read_capacity_units": 1,
+          "write_capacity_units": 1
+        }
+      }
+      """
+    Then eventually the table should exist in DynamoDB
+    And the table should have a local secondary index named "title"

--- a/features/secondary_indexes.feature
+++ b/features/secondary_indexes.feature
@@ -64,3 +64,36 @@ Feature: Amazon DynamoDB Secondary Indexes
       """
     Then eventually the table should exist in DynamoDB
     And the table should have a local secondary index named "title"
+
+  Scenario: Create a DynamoDB Table with a Global Secondary Index
+    When we add a global secondary index to the model with parameters:
+      """
+      [
+        "author",
+        {
+          "hash_key": "forum_name",
+          "range_key": "author_name",
+          "projection": {
+            "projection_type": "ALL"
+          }
+        }
+      ]
+      """
+    And we create a table migration for the model
+    And we call 'create!' with parameters:
+      """
+      {
+        "provisioned_throughput": {
+          "read_capacity_units": 1,
+          "write_capacity_units": 1
+        },
+        "global_secondary_index_throughput": {
+          "author": {
+            "read_capacity_units": 1,
+            "write_capacity_units": 1
+          }
+        }
+      }
+      """
+    Then eventually the table should exist in DynamoDB
+    And the table should have a global secondary index named "author"

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -72,6 +72,7 @@ Given(/^an aws\-record model with data:$/) do |string|
   @model = Class.new do
     include(Aws::Record)
   end
+  @model.configure_client(client: @client)
   @table_name ||= "test_table_#{SecureRandom.uuid}"
   @model.set_table_name(@table_name)
   data.each do |row|
@@ -149,7 +150,7 @@ Then(/^the DynamoDB table should not have an object with key values:$/) do |stri
 end
 
 When(/^we create a table migration for the model$/) do
-  @migration = Aws::Record::TableMigration.new(@model)
+  @migration = Aws::Record::TableMigration.new(@model, client: @client)
 end
 
 When(/^we call 'create!' with parameters:$/) do |string|

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -247,3 +247,18 @@ Then(/^the table should have a local secondary index named "([^"]*)"$/) do |expe
   exists = lsis && lsis.any? { |index| index.index_name == expected }
   expect(exists).to eq(true)
 end
+
+When(/^we add a global secondary index to the model with parameters:$/) do |string|
+  name, hash = JSON.parse(string, symbolize_names: true)
+  name = name.to_sym
+  hash[:hash_key] = hash[:hash_key].to_sym
+  hash[:range_key] = hash[:range_key].to_sym
+  @model.global_secondary_index(name, hash)
+end
+
+Then(/^the table should have a global secondary index named "([^"]*)"$/) do |expected|
+  resp = @client.describe_table(table_name: @table_name)
+  gsis = resp.table.global_secondary_indexes
+  exists = gsis && gsis.any? { |index| index.index_name == expected }
+  expect(exists).to eq(true)
+end

--- a/features/tables.feature
+++ b/features/tables.feature
@@ -12,7 +12,7 @@
 # and limitations under the License.
 
 # language: en
-@table
+@dynamodb @table
 Feature: Amazon DynamoDB Tables
   This feature tests the integration of model classes that include the
   Aws::Record module with the Aws::Record::TableMigration class, which helps to

--- a/lib/aws-record.rb
+++ b/lib/aws-record.rb
@@ -20,7 +20,9 @@ module Aws
     autoload :Attribute,      'aws-record/record/attribute'
     autoload :Attributes,     'aws-record/record/attributes'
     autoload :Errors,         'aws-record/record/errors'
+    autoload :ItemCollection, 'aws-record/record/item_collection'
     autoload :ItemOperations, 'aws-record/record/item_operations'
+    autoload :Query,          'aws-record/record/query'
     autoload :TableMigration, 'aws-record/record/table_migration'
     autoload :VERSION,        'aws-record/record/version'
 

--- a/lib/aws-record.rb
+++ b/lib/aws-record.rb
@@ -17,14 +17,15 @@ module Aws
   autoload :Record, 'aws-record/record'
 
   module Record
-    autoload :Attribute,      'aws-record/record/attribute'
-    autoload :Attributes,     'aws-record/record/attributes'
-    autoload :Errors,         'aws-record/record/errors'
-    autoload :ItemCollection, 'aws-record/record/item_collection'
-    autoload :ItemOperations, 'aws-record/record/item_operations'
-    autoload :Query,          'aws-record/record/query'
-    autoload :TableMigration, 'aws-record/record/table_migration'
-    autoload :VERSION,        'aws-record/record/version'
+    autoload :Attribute,        'aws-record/record/attribute'
+    autoload :Attributes,       'aws-record/record/attributes'
+    autoload :Errors,           'aws-record/record/errors'
+    autoload :ItemCollection,   'aws-record/record/item_collection'
+    autoload :ItemOperations,   'aws-record/record/item_operations'
+    autoload :Query,            'aws-record/record/query'
+    autoload :SecondaryIndexes, 'aws-record/record/secondary_indexes'
+    autoload :TableMigration,   'aws-record/record/table_migration'
+    autoload :VERSION,          'aws-record/record/version'
 
     module Attributes
       autoload :StringMarshaler,   'aws-record/record/attributes/string_marshaler'

--- a/lib/aws-record/record.rb
+++ b/lib/aws-record/record.rb
@@ -27,6 +27,7 @@ module Aws
       sub_class.include(Attributes)
       sub_class.include(ItemOperations)
       sub_class.include(Query)
+      sub_class.include(SecondaryIndexes)
     end
 
     private

--- a/lib/aws-record/record.rb
+++ b/lib/aws-record/record.rb
@@ -23,11 +23,11 @@ module Aws
     #     # Attribute definitions go here...
     #   end
     def self.included(sub_class)
-      sub_class.extend(RecordClassMethods)
-      sub_class.include(Attributes)
-      sub_class.include(ItemOperations)
-      sub_class.include(Query)
-      sub_class.include(SecondaryIndexes)
+      sub_class.send(:extend, RecordClassMethods)
+      sub_class.send(:include, Attributes)
+      sub_class.send(:include, ItemOperations)
+      sub_class.send(:include, Query)
+      sub_class.send(:include, SecondaryIndexes)
     end
 
     private

--- a/lib/aws-record/record.rb
+++ b/lib/aws-record/record.rb
@@ -26,6 +26,7 @@ module Aws
       sub_class.extend(RecordClassMethods)
       sub_class.include(Attributes)
       sub_class.include(ItemOperations)
+      sub_class.include(Query)
     end
 
     private

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -187,10 +187,6 @@ module Aws
           @keys
         end
 
-        def storage_attributes
-          @storage_attributes
-        end
-
         private
         def define_attr_methods(name, attribute)
           define_method(name) do

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -166,6 +166,11 @@ module Aws
           @attributes
         end
 
+        # @return [Hash] hash of database names to attribute names
+        def storage_attributes
+          @storage_attributes
+        end
+
         # @return [Aws::Record::Attribute,nil]
         def hash_key
           @attributes[@keys[:hash]]
@@ -180,6 +185,10 @@ module Aws
         #   name symbols associated with them.
         def keys
           @keys
+        end
+
+        def storage_attributes
+          @storage_attributes
         end
 
         private

--- a/lib/aws-record/record/item_collection.rb
+++ b/lib/aws-record/record/item_collection.rb
@@ -1,0 +1,42 @@
+module Aws
+  module Record
+    class ItemCollection
+      include Enumerable
+
+      def initialize(search_method, search_params, model, client)
+        @search_method = search_method
+        @search_params = search_params
+        @model = model
+        @client = client
+      end
+
+      def each(&block)
+        return enum_for(:each) unless block_given?
+        unless @result
+          @result = @client.send(@search_method, @search_params)
+        end
+        @result.each_page do |page|
+          items = _build_items_from_response(page.items, @model)
+          items.each do |item|
+            yield item
+          end
+        end
+      end
+
+      private
+      def _build_items_from_response(items, model)
+        ret = []
+        items.each do |item|
+          record = model.new
+          data = record.instance_variable_get("@data")
+          model.attributes.each do |name, attr|
+            data[name] = attr.extract(item)
+          end
+          ret << record
+        end
+        ret
+      end
+
+    end
+  end
+end

--- a/lib/aws-record/record/query.rb
+++ b/lib/aws-record/record/query.rb
@@ -21,11 +21,30 @@ module Aws
       end
 
       module QueryClassMethods
+
+        # This method calls
+        # {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#query-instance_method Aws::DynamoDB::Client#query},
+        # populating the +:table_name+ parameter from the model class, and
+        # combining this with the other parameters you provide.
+        #
+        # @param [Hash] opts options to pass on to the client call to +#query+.
+        #   See the documentation above in the AWS SDK for Ruby V2.
+        # @return [Aws::Record::ItemCollection] an enumerable collection of the
+        #   query result.
         def query(opts)
           query_opts = opts.merge(table_name: table_name)
           ItemCollection.new(:query, query_opts, self, dynamodb_client)
         end
 
+        # This method calls
+        # {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#scan-instance_method Aws::DynamoDB::Client#scan},
+        # populating the +:table_name+ parameter from the model class, and
+        # combining this with the other parameters you provide.
+        #
+        # @param [Hash] opts options to pass on to the client call to +#scan+.
+        #   See the documentation above in the AWS SDK for Ruby V2.
+        # @return [Aws::Record::ItemCollection] an enumerable collection of the
+        #   scan result.
         def scan(opts = {})
           scan_opts = opts.merge(table_name: table_name)
           ItemCollection.new(:scan, scan_opts, self, dynamodb_client)

--- a/lib/aws-record/record/query.rb
+++ b/lib/aws-record/record/query.rb
@@ -1,0 +1,37 @@
+# Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+module Aws
+  module Record
+    module Query
+
+      # @api private
+      def self.included(sub_class)
+        sub_class.extend(QueryClassMethods)
+      end
+
+      module QueryClassMethods
+        def query(opts)
+          query_opts = opts.merge(table_name: table_name)
+          ItemCollection.new(:query, query_opts, self, dynamodb_client)
+        end
+
+        def scan(opts = {})
+          scan_opts = opts.merge(table_name: table_name)
+          ItemCollection.new(:scan, scan_opts, self, dynamodb_client)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/aws-record/record/secondary_indexes.rb
+++ b/lib/aws-record/record/secondary_indexes.rb
@@ -1,0 +1,110 @@
+# Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+module Aws
+  module Record
+    module SecondaryIndexes
+
+      # @api private
+      def self.included(sub_class)
+        sub_class.instance_variable_set("@local_secondary_indexes", {})
+        sub_class.extend(SecondaryIndexesClassMethods)
+      end
+
+      module SecondaryIndexesClassMethods
+
+        # Creates a local secondary index for the model. Learn more about Local
+        # Secondary Indexes in the
+        # {http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LSI.html Amazon DynamoDB Developer Guide}.
+        #
+        # @param [Symbol] name index name for this local secondary index
+        # @param [Hash] opts
+        # @option opts [Symbol] :range_key the range key used by this local
+        #   secondary index. Note that the hash key MUST be the table's hash
+        #   key, and so that value will be filled in for you.
+        # @option opts [Hash] :projection a hash which defines which attributes
+        #   are copies from the table to the index. See shape details in the
+        #   {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Types/Projection.html AWS SDK for Ruby V2 docs}.
+        def local_secondary_index(name, opts)
+          opts[:hash_key] = hash_key.name
+          _validate_required_lsi_keys(opts)
+          _lsis[name] = opts
+        end
+
+        # @return [Hash] hash of local secondary index names to the index's
+        #   attributes.
+        def local_secondary_indexes
+          @local_secondary_indexes
+        end
+
+        # @return [Hash] hash of the local secondary index in a form suitable
+        #   for use in a table migration. For example, any attributes which
+        #   have a unique database storage name will use that name instead.
+        def local_secondary_indexes_for_migration
+          return nil if _lsis.empty?
+          _lsis.collect do |name, opts|
+            h = { index_name: name }
+            h[:key_schema] = _si_key_schema(opts)
+            opts.delete(:hash_key)
+            opts.delete(:range_key)
+            h = h.merge(opts)
+            h
+          end
+        end
+
+        private
+        def _lsis
+          @local_secondary_indexes
+        end
+
+        def _si_key_schema(opts)
+          key_schema = [{
+            key_type: "HASH",
+            attribute_name: @attributes[opts[:hash_key]].database_name
+          }]
+          if opts[:range_key]
+            key_schema << {
+              key_type: "RANGE",
+              attribute_name: @attributes[opts[:range_key]].database_name
+            }
+          end
+          key_schema
+        end
+
+        def _validate_required_lsi_keys(params)
+          if params[:hash_key] && params[:range_key]
+            _validate_attributes_exist(params[:hash_key], params[:range_key])
+          else
+            raise ArgumentError.new(
+              "Local Secondary Indexes require a hash and range key!"
+            )
+          end
+        end
+
+        def _validate_attributes_exist(*attr_names)
+          missing = attr_names.select do |attr_name|
+            @attributes[attr_name].nil?
+          end
+          unless missing.empty?
+            raise ArgumentError.new(
+              "#{missing.join(", ")} not present in model attributes."\
+                " Please ensure that attributes are defined in the model"\
+                " class BEFORE defining a index on those attributes."
+            )
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/aws-record/record/secondary_indexes.rb
+++ b/lib/aws-record/record/secondary_indexes.rb
@@ -76,23 +76,20 @@ module Aws
         #   for use in a table migration. For example, any attributes which
         #   have a unique database storage name will use that name instead.
         def local_secondary_indexes_for_migration
-          return nil if local_secondary_indexes.empty?
-          local_secondary_indexes.collect do |name, opts|
-            h = { index_name: name }
-            h[:key_schema] = _si_key_schema(opts)
-            opts.delete(:hash_key)
-            opts.delete(:range_key)
-            h = h.merge(opts)
-            h
-          end
+          _migration_format_indexes(local_secondary_indexes)
         end
 
         # @return [Hash] hash of the global secondary indexes in a form suitable
         #   for use in a table migration. For example, any attributes which
         #   have a unique database storage name will use that name instead.
         def global_secondary_indexes_for_migration
-          return nil if global_secondary_indexes.empty?
-          global_secondary_indexes.collect do |name, opts|
+          _migration_format_indexes(global_secondary_indexes)
+        end
+
+        private
+        def _migration_format_indexes(indexes)
+          return nil if indexes.empty?
+          indexes.collect do |name, opts|
             h = { index_name: name }
             h[:key_schema] = _si_key_schema(opts)
             opts.delete(:hash_key)
@@ -102,7 +99,6 @@ module Aws
           end
         end
 
-        private
         def _si_key_schema(opts)
           key_schema = [{
             key_type: "HASH",

--- a/spec/aws-record/record/item_collection_spec.rb
+++ b/spec/aws-record/record/item_collection_spec.rb
@@ -1,0 +1,80 @@
+# Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+require 'spec_helper'
+
+module Aws
+  module Record
+    describe ItemCollection do
+
+      let(:model) do
+        Class.new do
+          include(Aws::Record)
+          set_table_name("TestTable")
+          integer_attr(:id, hash_key: true)
+        end
+      end
+
+      let(:api_requests) { [] }
+
+      let(:stub_client) do
+        requests = api_requests
+        client = Aws::DynamoDB::Client.new(stub_responses: true)
+        client.handle do |context|
+          requests << context.params
+          @handler.call(context)
+        end
+        client
+      end
+
+      describe "#each" do
+        let(:truncated_resp) do
+          {
+            items: [
+              { "id" => 1 },
+              { "id" => 2 },
+              { "id" => 3 }
+            ],
+            count: 3,
+            last_evaluated_key: { "id" => { n: "3" } }
+          }
+        end
+
+        let(:non_truncated_resp) do
+          {
+            items: [
+              { "id" => 4 },
+              { "id" => 5 }
+            ],
+            count: 2,
+            last_evaluated_key: nil
+          }
+        end
+
+        it "correctly iterates through a paginated response" do
+          stub_client.stub_responses(:scan, truncated_resp, non_truncated_resp)
+          c = ItemCollection.new(
+            :scan,
+            { table_name: "TestTable" },
+            model,
+            stub_client
+          )
+          expected = [1,2,3,4,5]
+          actual = c.map { |item| item.id }
+          expect(actual).to eq(expected)
+        end
+      end
+
+    end
+  end
+end

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -59,6 +59,7 @@ module Aws
         end
 
         it 'raises an error when you try to save without setting keys' do
+          klass.configure_client(client: stub_client)
           no_keys = klass.new
           expect { no_keys.save }.to raise_error(
             Errors::KeyMissing,
@@ -72,7 +73,7 @@ module Aws
           )
           no_range = klass.new
           no_range.id = 5
-          expect { no_range.save}.to raise_error(
+          expect { no_range.save }.to raise_error(
             Errors::KeyMissing,
             "Missing required keys: date"
           )

--- a/spec/aws-record/record/query_spec.rb
+++ b/spec/aws-record/record/query_spec.rb
@@ -1,0 +1,120 @@
+# Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+require 'spec_helper'
+
+module Aws
+  module Record
+    describe "Query" do
+
+      let(:klass) do
+        Class.new do
+          include(Aws::Record)
+          set_table_name("TestTable")
+          integer_attr(:id, hash_key: true)
+          date_attr(:date, range_key: true)
+          string_attr(:body)
+        end
+      end
+
+      let(:api_requests) { [] }
+
+      let(:stub_client) do
+        requests = api_requests
+        client = Aws::DynamoDB::Client.new(stub_responses: true)
+        client.handle do |context|
+          requests << context.params
+          @handler.call(context)
+        end
+        client
+      end
+
+      describe "#query" do
+        it 'can pass on a manually constructed query to the client' do
+          stub_client.stub_responses(:query,
+            {
+              items: [
+                {
+                  "id" => 1,
+                  "date" => "2016-01-25",
+                  "body" => "Item 1"
+                },
+                {
+                  "id" => 1,
+                  "date" => "2016-01-26",
+                  "body" => "Item 2"
+                }
+              ],
+              count: 2,
+              scanned_count: 2,
+              last_evaluated_key: nil
+            })
+          klass.configure_client(client: stub_client)
+          query_opts = {
+            key_conditions: {
+              id: {
+                attribute_value_list: [1],
+                comparison_operator: "EQ"
+              },
+              date: {
+                attribute_value_list: ["2016-01-01"],
+                comparison_operator: "GT"
+              }
+            }
+          }
+          ret = klass.query(query_opts).to_a
+          expect(api_requests).to eq([{
+            table_name: "TestTable",
+            key_conditions: {
+              "id" => {
+                attribute_value_list: [{ n: "1" }],
+                comparison_operator: "EQ"
+              },
+              "date" => {
+                attribute_value_list: [{ s: "2016-01-01" }],
+                comparison_operator: "GT"
+              }
+            }
+          }])
+        end
+      end
+
+      describe "#scan" do
+        it 'can pass on a manually constructed scan to the client' do
+          stub_client.stub_responses(:scan,
+            {
+              items: [
+                {
+                  "id" => 1,
+                  "date" => "2016-01-25",
+                  "body" => "Item 1"
+                },
+                {
+                  "id" => 1,
+                  "date" => "2016-01-26",
+                  "body" => "Item 2"
+                }
+              ],
+              count: 2,
+              scanned_count: 2,
+              last_evaluated_key: nil
+            })
+          klass.configure_client(client: stub_client)
+          ret = klass.scan.to_a
+          expect(api_requests).to eq([{ table_name: "TestTable" }])
+        end
+      end
+
+    end
+  end
+end

--- a/spec/aws-record/record/secondary_indexes_spec.rb
+++ b/spec/aws-record/record/secondary_indexes_spec.rb
@@ -1,0 +1,106 @@
+# Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+require 'spec_helper'
+
+module Aws
+  module Record
+    describe "SecondaryIndexes" do
+
+      let(:klass) do
+        Class.new do
+          include(Aws::Record)
+          set_table_name("TestTable")
+          integer_attr(:forum_id, hash_key: true)
+          integer_attr(:post_id, range_key: true)
+          string_attr(:forum_name)
+          string_attr(:post_title)
+          integer_attr(:author_id, database_attribute_name: 'a_id')
+          string_attr(:author_name)
+          string_attr(:post_body)
+        end
+      end
+
+      let(:api_requests) { [] }
+
+      let(:stub_client) do
+        requests = api_requests
+        client = Aws::DynamoDB::Client.new(stub_responses: true)
+        client.handle do |context|
+          requests << context.params
+          @handler.call(context)
+        end
+        client
+      end
+
+      context "Local Secondary Index" do
+
+        describe "#local_secondary_index" do
+          it 'allows you to define a local secondary index on the model' do
+            klass.local_secondary_index(
+              :title,
+              range_key: :post_title,
+              projection: {
+                projection_type: "ALL"
+              }
+            )
+            expect(klass.local_secondary_indexes[:title]).not_to eq(nil)
+          end
+
+          it 'requires that a range key is provided' do
+            expect {
+              klass.local_secondary_index(
+                :fail,
+                projection: { projection_type: "ALL" }
+              )
+            }.to raise_error(ArgumentError)
+          end
+
+          it 'requires use of an attribute that exists in the model' do
+            expect {
+              klass.local_secondary_index(
+                :fail,
+                range_key: :missingno,
+                projection: { projection_type: "ALL" }
+              )
+            }.to raise_error(ArgumentError)
+          end
+        end
+
+        describe "#local_secondary_indexes_for_migration" do
+          it 'correctly translates database names for migration' do
+            klass.local_secondary_index(
+              :author,
+              range_key: :author_id,
+              projection: {
+                projection_type: "ALL"
+              }
+            )
+            migration = klass.local_secondary_indexes_for_migration
+            expect(migration.size).to eq(1)
+            expect(migration.first).to eq({
+              index_name: :author,
+              key_schema: [
+                { key_type: "HASH", attribute_name: "forum_id" },
+                { key_type: "RANGE", attribute_name: "a_id" }
+              ],
+              projection: { projection_type: "ALL" }
+            })
+          end
+        end
+
+      end
+
+    end
+  end
+end

--- a/spec/aws-record/record/table_migration_spec.rb
+++ b/spec/aws-record/record/table_migration_spec.rb
@@ -57,7 +57,7 @@ module Aws
         end
 
         let(:migration) do
-          TableMigration.new(klass)
+          TableMigration.new(klass, client: stub_client)
         end
 
         context "#create!" do

--- a/spec/aws-record/record/table_migration_spec.rb
+++ b/spec/aws-record/record/table_migration_spec.rb
@@ -53,6 +53,8 @@ module Aws
             integer_attr(:id, hash_key: true)
             date_attr(:date, range_key: true)
             string_attr(:lsi)
+            string_attr(:gsi_partition)
+            string_attr(:gsi_sort)
           end
         end
 
@@ -162,6 +164,144 @@ module Aws
                 write_capacity_units: 2
               }
             }])
+          end
+
+          it 'accepts models with a global secondary index' do
+            create_opts = {
+              provisioned_throughput: {
+                read_capacity_units: 5,
+                write_capacity_units: 2
+              },
+              global_secondary_index_throughput: {
+                test_gsi: {
+                  read_capacity_units: 3,
+                  write_capacity_units: 1
+                }
+              }
+            }
+            klass.global_secondary_index(
+              :test_gsi,
+              hash_key: :gsi_partition,
+              range_key: :gsi_sort,
+              projection: {
+                projection_type: "ALL"
+              }
+            )
+            migration.client = stub_client
+            migration.create!(create_opts)
+            expect(api_requests).to eq([{
+              table_name: "TestTable",
+              attribute_definitions: [
+                {
+                  attribute_name: "id",
+                  attribute_type: "N"
+                },
+                {
+                  attribute_name: "date",
+                  attribute_type: "S"
+                },
+                {
+                  attribute_name: "gsi_partition",
+                  attribute_type: "S"
+                },
+                {
+                  attribute_name: "gsi_sort",
+                  attribute_type: "S"
+                }
+              ],
+              key_schema: [
+                {
+                  attribute_name: "id",
+                  key_type: "HASH"
+                },
+                {
+                  attribute_name: "date",
+                  key_type: "RANGE"
+                }
+              ],
+              global_secondary_indexes: [{
+                index_name: "test_gsi",
+                key_schema: [
+                  {
+                    attribute_name: "gsi_partition",
+                    key_type: "HASH"
+                  },
+                  {
+                    attribute_name: "gsi_sort",
+                    key_type: "RANGE"
+                  }
+                ],
+                projection: {
+                  projection_type: "ALL"
+                },
+                provisioned_throughput: {
+                  read_capacity_units: 3,
+                  write_capacity_units: 1
+                }
+              }],
+              provisioned_throughput: {
+                read_capacity_units: 5,
+                write_capacity_units: 2
+              }
+            }])
+          end
+
+          it 'required global secondary index throughput to be provided' do
+            create_opts = {
+              provisioned_throughput: {
+                read_capacity_units: 5,
+                write_capacity_units: 2
+              }
+            }
+            klass.global_secondary_index(
+              :test_gsi,
+              hash_key: :gsi_partition,
+              range_key: :gsi_sort,
+              projection: {
+                projection_type: "ALL"
+              }
+            )
+            migration.client = stub_client
+            expect { migration.create!(create_opts) }.to raise_error(
+              ArgumentError
+            )
+            expect(api_requests).to eq([])
+          end
+
+          it 'requires global secondary index throughput to be defined for each index' do
+            create_opts = {
+              provisioned_throughput: {
+                read_capacity_units: 5,
+                write_capacity_units: 2
+              },
+              global_secondary_index_throughput: {
+                test_gsi: {
+                  read_capacity_units: 1,
+                  write_capacity_units: 1
+                }
+              }
+            }
+            klass.global_secondary_index(
+              :test_gsi,
+              hash_key: :gsi_partition,
+              range_key: :gsi_sort,
+              projection: {
+                projection_type: "ALL"
+              }
+            )
+            klass.global_secondary_index(
+              :fail_on,
+              hash_key: :gsi_partition,
+              range_key: :gsi_sort,
+              projection: {
+                projection_type: "ALL"
+              }
+            )
+            migration.client = stub_client
+            expect { migration.create!(create_opts) }.to raise_error(
+              ArgumentError
+            )
+            expect(api_requests).to eq([])
           end
         end
 


### PR DESCRIPTION
Adds basic querying support to `Aws::Record`, via direct interfaces to the underlying `Aws::DynamoDB::Client#query` and `Aws::DynamoDB::Client#scan` methods, and showing the results via the `Aws::Record::ItemCollection` enumerable.