### PR TITLE
Add save! and save methods

### DIFF
--- a/lib/aws-record/record/errors.rb
+++ b/lib/aws-record/record/errors.rb
@@ -15,12 +15,14 @@ module Aws
   module Record
     module Errors
 
-      class KeyMissing < RuntimeError; end
-      class NameCollision < RuntimeError; end
-      class ReservedName < RuntimeError; end
-      class NotFound < RuntimeError; end
-      class InvalidModel < RuntimeError; end
-      class TableDoesNotExist < RuntimeError; end
+      class RecordError < RuntimeError; end
+
+      class KeyMissing < RecordError; end
+      class NameCollision < RecordError; end
+      class ReservedName < RecordError; end
+      class NotFound < RecordError; end
+      class InvalidModel < RecordError; end
+      class TableDoesNotExist < RecordError; end
 
     end
   end

--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -42,7 +42,7 @@ module Aws
         result = save!
         errors.clear
         result
-      rescue Errors::KeyMissing => e
+      rescue Errors::RecordError => e
         errors << e.message
         false
       end

--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -39,9 +39,12 @@ module Aws
       # invalid. Matches style of ActiveRecord save and save! methods.
       #
       def save
-        save!
+        result = save!
+        errors.clear
+        result
       rescue Errors::KeyMissing => e
         errors << e.message
+        false
       end
 
       # Is the record a valid record. True if #save was successful, false if

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -148,6 +148,22 @@ module Aws
           # None of this should have reached the API
           expect(api_requests).to eq([])
         end
+
+        it 'is valid after fixing invalid save state' do
+          klass.configure_client(client: stub_client)
+          item = klass.new
+          item.save
+          expect(item.valid?).to be_falsy
+
+          item.id = 1
+          item.date = '2015-12-14'
+          item.body = 'Hello!'
+          item.save
+          expect(item.valid?).to be_truthy
+
+          # None of this should have reached the API
+          expect(api_requests).not_to be_empty
+        end
       end
 
       describe "#find" do


### PR DESCRIPTION
Break out the save method to match more closely with
Ruby style of <method>! to raise an error while
<method> fails silently. Implemented to work like
ActiveRecord's save where an unsuccessful save will
mark the record as invalid.