### PR TITLE
Conditional Put, Force Put, and Update for #save

### DIFF
--- a/features/item_updates.feature
+++ b/features/item_updates.feature
@@ -1,0 +1,185 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+# language: en
+@dynamodb @item @update
+Feature: Amazon DynamoDB Item Updates
+  This feature tests functionality designed to prefer update calls to put calls
+  when possible, in order to avoid accidental overwrite of unmodeled fields. For
+  example, this kind of feature is useful in single-table inheritance scenarios,
+  where the same table may serve multiple models. It also provides safety checks
+  against overwriting existing items, if unintended. To run these tests, you
+  will need to have valid AWS credentials that are accessible with the AWS SDK
+  for Ruby's standard credential provider chain. In practice, this means a
+  shared credential file or environment variables with your credentials. These
+  tests may have some AWS costs associated with running them since AWS resources
+  are created and destroyed within these tests.
+
+  Background:
+    Given a DynamoDB table named 'shared' with data:
+      """
+      [
+        { "attribute_name": "hk", "attribute_type": "S", "key_type": "HASH" },
+        { "attribute_name": "rk", "attribute_type": "S", "key_type": "RANGE" }
+      ]
+      """
+    And an item exists in the DynamoDB table with item data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample",
+        "x": "x",
+        "y": "y",
+        "z": "z"
+      }
+      """
+
+  Scenario: Overwriting an Existing Object With #put_item Fails Without :force
+    Given an aws-record model with data:
+      """
+      [
+        { "method": "string_attr", "name": "hk", "hash_key": true },
+        { "method": "string_attr", "name": "rk", "range_key": true },
+        { "method": "string_attr", "name": "x" },
+        { "method": "string_attr", "name": "y" },
+        { "method": "string_attr", "name": "z" }
+      ]
+      """
+    When we create a new instance of the model with attribute value pairs:
+      """
+      [
+        ["hk", "sample"],
+        ["rk", "sample"],
+        ["x", "foo"]
+      ]
+      """
+    And we save the model instance
+    Then the return value of save should be false
+    And we call the 'find' class method with parameter data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample"
+      }
+      """
+    And we should receive an aws-record item with attribute data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample",
+        "x": "x",
+        "y": "y",
+        "z": "z"
+      }
+      """
+  Scenario: Updating an Object Does Not Clobber Unmodeled Attributes
+    Given an aws-record model with data:
+      """
+      [
+        { "method": "string_attr", "name": "hk", "hash_key": true },
+        { "method": "string_attr", "name": "rk", "range_key": true },
+        { "method": "string_attr", "name": "x" }
+      ]
+      """
+    When we call the 'find' class method with parameter data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample"
+      }
+      """
+    And we set the item attribute "x" to be "bar"
+    And we save the model instance
+    Then an aws-record model with data:
+      """
+      [
+        { "method": "string_attr", "name": "hk", "hash_key": true },
+        { "method": "string_attr", "name": "rk", "range_key": true },
+        { "method": "string_attr", "name": "x" },
+        { "method": "string_attr", "name": "y" },
+        { "method": "string_attr", "name": "z" }
+      ]
+      """
+    And we call the 'find' class method with parameter data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample"
+      }
+      """
+    Then we should receive an aws-record item with attribute data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample",
+        "x": "bar",
+        "y": "y",
+        "z": "z"
+      }
+      """
+    
+  Scenario: Updating an Object Does Not Clobber Non-Dirty Attributes
+    Given an aws-record model with data:
+      """
+      [
+        { "method": "string_attr", "name": "hk", "hash_key": true },
+        { "method": "string_attr", "name": "rk", "range_key": true },
+        { "method": "string_attr", "name": "x" },
+        { "method": "string_attr", "name": "y" },
+        { "method": "string_attr", "name": "z" }
+      ]
+      """
+    When we call the 'query' class method with parameter data:
+      """
+      {
+        "key_conditions": {
+          "hk": {
+            "attribute_value_list": ["sample"],
+            "comparison_operator": "EQ"
+          }
+        },
+        "projection_expression": "hk, rk, x, y"
+      }
+      """
+    And we should receive an aws-record collection with members:
+      """
+      [
+        {
+          "hk": "sample",
+          "rk": "sample",
+          "x": "x",
+          "y": "y",
+          "z": null
+        }
+      ]
+      """
+    And we take the first member of the result collection
+    And we set the item attribute "y" to be "foo"
+    And we save the model instance
+    And we call the 'find' class method with parameter data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample"
+      }
+      """
+    Then we should receive an aws-record item with attribute data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample",
+        "x": "x",
+        "y": "foo",
+        "z": "z"
+      }
+      """

--- a/features/search.feature
+++ b/features/search.feature
@@ -93,12 +93,12 @@ Feature: Amazon DynamoDB Querying and Scanning
         {
           "id": "1",
           "count": 10,
-          "content": "Second item."
+          "body": "Second item."
         },
         {
           "id": "1",
           "count": 15,
-          "content": "Third item."
+          "body": "Third item."
         }
       ]
       """
@@ -111,22 +111,22 @@ Feature: Amazon DynamoDB Querying and Scanning
         {
           "id": "1",
           "count": 5,
-          "content": "First item."
+          "body": "First item."
         },
         {
           "id": "1",
           "count": 10,
-          "content": "Second item."
+          "body": "Second item."
         },
         {
           "id": "1",
           "count": 15,
-          "content": "Third item."
+          "body": "Third item."
         },
         {
           "id": "2",
           "count": 10,
-          "content": "Fourth item."
+          "body": "Fourth item."
         }
       ]
       """

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -94,7 +94,7 @@ When(/^we create a new instance of the model with attribute value pairs:$/) do |
 end
 
 When(/^we save the model instance$/) do
-  @instance.save
+  @save_output = @instance.save
 end
 
 Then(/^the DynamoDB table should have an object with key values:$/) do |string|
@@ -212,12 +212,8 @@ Then(/^we should receive an aws\-record collection with members:$/) do |string|
   expect(expected.size).to eq(@collection.to_a.size)
   # Results do not have guaranteed order, check each expected value individually
   @collection.each do |item|
-    h = {
-      id: item.id,
-      count: item.count,
-      content: item.body # Because of database special name.
-    }
-    expect(expected.any? { |expect| h == expect }).to eq(true)
+    h = item.to_h
+    expect(expected.any? { |e| h == e }).to eq(true)
   end
 end
 
@@ -261,4 +257,16 @@ Then(/^the table should have a global secondary index named "([^"]*)"$/) do |exp
   gsis = resp.table.global_secondary_indexes
   exists = gsis && gsis.any? { |index| index.index_name == expected }
   expect(exists).to eq(true)
+end
+
+Then(/^the return value of save should be false$/) do
+  expect(@save_output).to eq(false)
+end
+
+When(/^we set the item attribute "([^"]*)" to be "([^"]*)"$/) do |attr, value|
+  @instance.send(:"#{attr}=", value)
+end
+
+When(/^we take the first member of the result collection$/) do
+  @instance = @collection.first
 end

--- a/lib/aws-record/record/errors.rb
+++ b/lib/aws-record/record/errors.rb
@@ -18,11 +18,13 @@ module Aws
       class RecordError < RuntimeError; end
 
       class KeyMissing < RecordError; end
-      class NameCollision < RecordError; end
-      class ReservedName < RecordError; end
       class NotFound < RecordError; end
-      class InvalidModel < RecordError; end
-      class TableDoesNotExist < RecordError; end
+      class ItemAlreadyExists < RecordError; end
+
+      class NameCollision < RuntimeError; end
+      class ReservedName < RuntimeError; end
+      class InvalidModel < RuntimeError; end
+      class TableDoesNotExist < RuntimeError; end
 
     end
   end

--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -123,7 +123,7 @@ module Aws
       end
 
       def errors
-        self.class.instance_variable_get("@errors").dup
+        self.class.instance_variable_get("@errors")
       end
 
       private


### PR DESCRIPTION
Currently, the `#save` and `#save!` methods call
`Aws::DynamoDB::Client#put_item`, and clobber whatever is on the remote
end.

With this change, dirty tracking functionality is utilized to decide
between three write approaches:

* Force Put: If the `:force` option is passed into the save call, then
  the legacy logic of a clobber/overwrite is always used.
* Conditional Put: If the object has dirty keys, it is treated as a new
  object and `Aws::DynamoDB::Client#put_item` is used, but with a
  condition check that will fail if the item exists on the remote end.
* Update: If no key attribute is dirty, then an
  `Aws::DynamoDB::Client#update_item` call is constructed and used. This
  will leave any unmodified or unmodeled attributes untouched.

This pull request also includes documentation changes, unit test
changes, and new integration tests to reflect the logic change.