### PR TITLE
Remove Built-In Validations, Test ActiveModel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test do
   gem 'cucumber'
   gem 'simplecov', require: false
   gem 'coveralls', require: false
+  gem 'activemodel'
 end
 
 group :docs do

--- a/features/item_updates.feature
+++ b/features/item_updates.feature
@@ -63,8 +63,7 @@ Feature: Amazon DynamoDB Item Updates
         ["x", "foo"]
       ]
       """
-    And we save the model instance
-    Then the return value of save should be false
+    Then calling save should raise an ItemAlreadyExists exception
     And we call the 'find' class method with parameter data:
       """
       {

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -259,8 +259,8 @@ Then(/^the table should have a global secondary index named "([^"]*)"$/) do |exp
   expect(exists).to eq(true)
 end
 
-Then(/^the return value of save should be false$/) do
-  expect(@save_output).to eq(false)
+Then(/^calling save should raise an ItemAlreadyExists exception$/) do
+  expect { @instance.save }.to raise_error(Aws::Record::Errors::ItemAlreadyExists)
 end
 
 When(/^we set the item attribute "([^"]*)" to be "([^"]*)"$/) do |attr, value|

--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -24,8 +24,6 @@ module Aws
       #   So long as you provide a marshaler which implements +#type_cast+ and
       #   +#serialize+ that consume raw values as expected, you can bring your
       #   own marshaler type.
-      # @option options [Array] :validators An array of validator classes that
-      #   will be run when an attribute is checked for validity.
       # @option options [String] :database_attribute_name Optional attribute
       #   used to specify a different name for database persistence than the
       #   `name` parameter. Must be unique (you can't have overlap between
@@ -40,7 +38,6 @@ module Aws
         @database_name = options[:database_attribute_name] || name.to_s
         @dynamodb_type = options[:dynamodb_type]
         @marshaler = options[:marshaler] || DefaultMarshaler
-        @validators = options[:validators] || []
       end
 
       # Attempts to type cast a raw value into the attribute's type. This call
@@ -60,19 +57,6 @@ module Aws
       #  marshaler used. See your attribute's marshaler class for details.
       def serialize(raw_value)
         @marshaler.serialize(raw_value)
-      end
-
-      # Checks if the raw value is valid for this attribute. This is done by
-      # type casting the raw value, then running that value through each
-      # validator present for this attribute.
-      #
-      # @return [Boolean] true if the raw value is valid for this attribute,
-      #  false if it is not.
-      def valid?(raw_value)
-        value = type_cast(raw_value)
-        @validators.all? do |validator|
-          validator.validate(value)
-        end
       end
 
       # @api private

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -24,7 +24,6 @@ module Aws
 
       def initialize
         @data = {}
-        @errors = []
       end
 
       # Returns a hash representation of the attribute data.
@@ -59,8 +58,6 @@ module Aws
         #   +#serialize+ that consume raw values as expected, you can bring your
         #   own marshaler type. Convenience methods will provide this for you.
         # @param [Hash] opts
-        # @option opts [Array] :validators An array of validator classes that
-        #   will be run when an attribute is checked for validity.
         # @option opts [String] :database_attribute_name Optional attribute
         #   used to specify a different name for database persistence than the
         #   `name` parameter. Must be unique (you can't have overlap between

--- a/lib/aws-record/record/errors.rb
+++ b/lib/aws-record/record/errors.rb
@@ -20,6 +20,7 @@ module Aws
       class KeyMissing < RecordError; end
       class NotFound < RecordError; end
       class ItemAlreadyExists < RecordError; end
+      class ValidationError < RecordError; end
 
       class NameCollision < RuntimeError; end
       class ReservedName < RuntimeError; end

--- a/spec/aws-record/record/attribute_spec.rb
+++ b/spec/aws-record/record/attribute_spec.rb
@@ -23,38 +23,6 @@ module Aws
         expect(a.database_name).to eq("bar")
       end
 
-      describe 'validation' do
-
-        let(:noop_validator) do
-          Class.new do
-            def self.validate(value)
-              true
-            end
-          end
-        end
-
-        let(:failure_validator) do
-          Class.new do
-            def self.validate(value)
-              false
-            end
-          end
-        end
-
-        it 'passes validation on to a validator chain' do
-          a = Attribute.new(:test, validators: [noop_validator])
-          expect(a.valid?("Hello")).to eq(true)
-        end
-
-        it 'fails validation if any validator in the chain fails' do
-          a = Attribute.new(
-            :test, validators: [failure_validator, noop_validator]
-          )
-          expect(a.valid?("Hello")).to eq(false)
-        end
-
-      end
-
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,3 +16,4 @@ require 'rspec'
 SimpleCov.start
 
 require 'aws-record'
+require 'active_model'


### PR DESCRIPTION
The previously accepted `#valid?` and `#errors` methods provided a
surface-level implementation of integrations, but were semantically
incorrect for a few reasons. Going back to original intent, this is a
persistence library but it is meant to support bringing your own
validation library.

This change adds unit tests around `ActiveModel::Validations`, ensuring
that we support ActiveModel-style validation behavior, including as a
`#save` and `#save!` hook. Users of `#valid?` and `#errors` can bring
their own validation library for code to return to expected
behavior. Client errors (as they should be exceptional cases) will once
again raise exceptions.

Resolves GitHub issue #14