### PR TITLE
Support Bulk Attribute Initialization and Update

### DIFF
--- a/features/item_updates.feature
+++ b/features/item_updates.feature
@@ -182,3 +182,41 @@ Feature: Amazon DynamoDB Item Updates
         "z": "z"
       }
       """
+
+  Scenario: Updating an Object with the Update Model Method
+    Given an aws-record model with data:
+      """
+      [
+        { "method": "string_attr", "name": "hk", "hash_key": true },
+        { "method": "string_attr", "name": "rk", "range_key": true },
+        { "method": "string_attr", "name": "x" },
+        { "method": "string_attr", "name": "y" },
+        { "method": "string_attr", "name": "z" }
+      ]
+      """
+    When we call the 'update' class method with parameter data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample",
+        "y": "foo",
+        "z": "bar"
+      }
+      """
+    And we call the 'find' class method with parameter data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample"
+      }
+      """
+    Then we should receive an aws-record item with attribute data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample",
+        "x": "x",
+        "y": "foo",
+        "z": "bar"
+      }
+      """

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -124,6 +124,11 @@ When(/^we call the 'find' class method with parameter data:$/) do |string|
   @instance = @model.find(data)
 end
 
+When(/^we call the 'update' class method with parameter data:$/) do |string|
+  data = JSON.parse(string, symbolize_names: true)
+  @model.update(data)
+end
+
 Then(/^we should receive an aws\-record item with attribute data:$/) do |string|
   data = JSON.parse(string, symbolize_names: true)
   data.each do |key, value|

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -22,8 +22,28 @@ module Aws
         sub_class.instance_variable_set("@storage_attributes", {})
       end
 
-      def initialize
+      # @example Usage Example
+      #   class MyModel
+      #     include Aws::Record
+      #     integer_attr :id,   hash_key: true
+      #     string_attr  :name, range_key: true
+      #     string_attr  :body
+      #   end
+      #
+      #   item = MyModel.new(id: 1, name: "Quick Create")
+      #
+      # Base initialization method for a new item. Optionally, allows you to
+      # provide initial attribute values for the model. You do not need to
+      # provide all, or even any, attributes at item creation time.
+      #
+      # @param [Hash] attr_values Attribute symbol/value pairs for any initial
+      #  attribute values you wish to set.
+      # @return [Aws::Record] An item instance for your model.
+      def initialize(attr_values = {})
         @data = {}
+        attr_values.each do |attr_name, attr_value|
+          send("#{attr_name}=", attr_value)
+        end
       end
 
       # Returns a hash representation of the attribute data.

--- a/lib/aws-record/record/dirty_tracking.rb
+++ b/lib/aws-record/record/dirty_tracking.rb
@@ -23,7 +23,8 @@ module Aws
       #
       # @override initialize(*)
       def initialize(*)
-        super.tap { @dirty_data = {} }
+        @dirty_data = {}
+        super
       end
 
       # Returns +true+ if the specified attribute has any dirty changes, +false+ otherwise.

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -23,6 +23,28 @@ module Aws
         end
       end
 
+      describe '#initialize' do
+        let(:model) do
+          Class.new do
+            include(Aws::Record)
+            string_attr(:id, hash_key: true)
+            string_attr(:body)
+          end
+        end
+
+        it 'should allow attribute assignment at item creation time' do
+          item = model.new(id: "MyId")
+          expect(item.id).to eq("MyId")
+          expect(item.body).to be_nil
+        end
+
+        it 'should allow assignment of multiple attributes at item creation' do
+          item = model.new(id: "MyId", body: "Hello!")
+          expect(item.id).to eq("MyId")
+          expect(item.body).to eq("Hello!")
+        end
+      end
+
       describe 'Keys' do
         it 'should be able to assign a hash key' do
           klass.string_attr(:mykey, hash_key: true)

--- a/spec/aws-record/record/dirty_tracking_spec.rb
+++ b/spec/aws-record/record/dirty_tracking_spec.rb
@@ -50,6 +50,11 @@ describe Aws::Record::DirtyTracking do
       instance.mykey = nil
       expect(instance.mykey_dirty?).to be false
     end
+
+    it "should recognize initialization values as dirty" do
+      item = klass.new(mykey: "Key", body: "Hello!")
+      expect(item.mykey_dirty?).to be_truthy
+    end
   end
 
   describe '#[attribute]_dirty!' do 


### PR DESCRIPTION
Provides two new pieces of functionality:

1. The ability to create a new item object with attributes set via the
constructor.
2. The ability to call `#update_item` directly from the model class via
the `update` method.

Resolves GitHub issue #15 