### PR TITLE
pull out ActiveModel::Validation error details

### DIFF
--- a/lib/aws-record.rb
+++ b/lib/aws-record.rb
@@ -23,6 +23,7 @@ module Aws
     autoload :Errors,           'aws-record/record/errors'
     autoload :ItemCollection,   'aws-record/record/item_collection'
     autoload :ItemOperations,   'aws-record/record/item_operations'
+    autoload :NullValidation,   'aws-record/record/null_validation'
     autoload :Query,            'aws-record/record/query'
     autoload :SecondaryIndexes, 'aws-record/record/secondary_indexes'
     autoload :TableMigration,   'aws-record/record/table_migration'

--- a/lib/aws-record/record/null_validation.rb
+++ b/lib/aws-record/record/null_validation.rb
@@ -1,0 +1,16 @@
+module Aws
+  module Record
+    class NullValidation
+      def initialize(record)
+      end
+
+      def validate!
+        yield
+      end
+
+      def valid?
+        true
+      end
+    end
+  end
+end

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -317,35 +317,63 @@ module Aws
       end
 
       describe "validations with ActiveModel::Validations" do
-        let(:klass_amv) do
-          ::TestTable = Class.new do
-            include(Aws::Record)
-            include(ActiveModel::Validations)
-            set_table_name("TestTable")
-            integer_attr(:id, hash_key: true)
-            date_attr(:date, range_key: true)
-            string_attr(:body)
-            boolean_attr(:bool, database_attribute_name: "my_boolean")
-            validates_presence_of(:id, :date)
+        class TestValidation
+          def initialize(record)
+            @record = record
+          end
+
+          def validate!
+            raise Aws::Record::Errors::ValidationError.new(error_message) unless valid?
+            yield
+          end
+
+          def valid?
+            @record.valid?
+          end
+
+          def error_message
+            @record.errors.full_messages.join(', ')
           end
         end
 
+        class ValidatableTestRecord
+          include Aws::Record
+          integer_attr :id, hash_key: true
+          string_attr :body
+
+          include ActiveModel::Validations
+          validates_presence_of :id, :body
+          set_validation_class TestValidation
+        end
+
         it 'will use ActiveModel::Validations :valid? method' do
-          klass_amv.configure_client(client: stub_client)
-          item = klass_amv.new
+          ValidatableTestRecord.configure_client(client: stub_client)
+          item = ValidatableTestRecord.new
           item.id = 3
           expect(item.save).to be_falsey
 
-          item.date = "2016-04-21"
           item.body = "Hello!"
           expect(item.save).to be_truthy
         end
 
         it 'will raise on an invalid model for #save!' do
-          klass_amv.configure_client(client: stub_client)
-          item = klass_amv.new
+          ValidatableTestRecord.configure_client(client: stub_client)
+          item = ValidatableTestRecord.new
           item.id = 3
           expect { item.save! }.to raise_error(Errors::ValidationError)
+        end
+
+        it 'raises the validation error messages' do
+          ValidatableTestRecord.configure_client(client: stub_client)
+          item = ValidatableTestRecord.new
+          item.id = 3
+          expect { item.save! }.to raise_error("Body can't be blank")
+        end
+
+        it 'joins the validation error messages' do
+          ValidatableTestRecord.configure_client(client: stub_client)
+          item = ValidatableTestRecord.new
+          expect { item.save! }.to raise_error("Id can't be blank, Body can't be blank")
         end
       end
 


### PR DESCRIPTION
for https://github.com/awslabs/aws-sdk-ruby-record/issues/24

considered also doing a hook method for consumers to be able to inject
their own validation error messages, but it’d be nice to not have to do
that on every consumer class.