### PR TITLE
Improve Dirty Tracking of Mutable Collection Types

### DIFF
--- a/lib/aws-record/record.rb
+++ b/lib/aws-record/record.rb
@@ -50,6 +50,7 @@ module Aws
     #     # Attribute definitions go here...
     #   end
     def self.included(sub_class)
+      @track_mutations = true
       sub_class.send(:extend, RecordClassMethods)
       sub_class.send(:include, Attributes)
       sub_class.send(:include, ItemOperations)
@@ -181,6 +182,26 @@ module Aws
       # @return [Aws::DynamoDB::Client] the Amazon DynamoDB client instance.
       def dynamodb_client
         @dynamodb_client ||= configure_client
+      end
+
+      # Turns off mutation tracking for all attributes in the model.
+      def disable_mutation_tracking
+        @track_mutations = false
+      end
+
+      # Turns on mutation tracking for all attributes in the model. Note that
+      # mutation tracking is on by default, so you generally would not need to
+      # call this. It is provided in case there is a need to dynamically turn
+      # this feature on and off, though that would be generally discouraged and
+      # could cause inaccurate mutation tracking at runtime.
+      def enable_mutation_tracking
+        @track_mutations = true
+      end
+
+      # @return [Boolean] true if mutation tracking is enabled at the model
+      # level, false otherwise.
+      def mutation_tracking_enabled?
+        @track_mutations == false ? false : true
       end
 
       private

--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -39,11 +39,17 @@ module Aws
       #   "M", "L". Optional if this attribute will never be used for a key or
       #   secondary index, but most convenience methods for setting attributes
       #   will provide this.
+      # @option options [Boolean] :mutation_tracking Optional attribute used to
+      #   indicate if mutations to values should be explicitly tracked when
+      #   determining if a value is "dirty". Important for collection types
+      #   which are often primarily modified by mutation of a single object
+      #   reference. By default, is false.
       def initialize(name, options = {})
         @name = name
         @database_name = options[:database_attribute_name] || name.to_s
         @dynamodb_type = options[:dynamodb_type]
         @marshaler = options[:marshaler] || DefaultMarshaler
+        @mutation_tracking = options[:mutation_tracking]
       end
 
       # Attempts to type cast a raw value into the attribute's type. This call
@@ -63,6 +69,12 @@ module Aws
       #  marshaler used. See your attribute's marshaler class for details.
       def serialize(raw_value)
         @marshaler.serialize(raw_value)
+      end
+
+      # @return [Boolean] true if this attribute should do active mutation
+      #  tracking, false otherwise.
+      def track_mutations?
+        @mutation_tracking ? true : false
       end
 
       # @api private

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -87,6 +87,11 @@ module Aws
         #   "M", "L". Optional if this attribute will never be used for a key or
         #   secondary index, but most convenience methods for setting attributes
         #   will provide this.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is false.
         # @option opts [Boolean] :hash_key Set to true if this attribute is
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
@@ -118,6 +123,11 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is false.
         def string_attr(name, opts = {})
           opts[:dynamodb_type] = "S"
           attr(name, Attributes::StringMarshaler, opts)
@@ -132,6 +142,11 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is false.
         def boolean_attr(name, opts = {})
           opts[:dynamodb_type] = "BOOL"
           attr(name, Attributes::BooleanMarshaler, opts)
@@ -146,6 +161,11 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is false.
         def integer_attr(name, opts = {})
           opts[:dynamodb_type] = "N"
           attr(name, Attributes::IntegerMarshaler, opts)
@@ -160,6 +180,11 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is false.
         def float_attr(name, opts = {})
           opts[:dynamodb_type] = "N"
           attr(name, Attributes::FloatMarshaler, opts)
@@ -174,6 +199,11 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is false.
         def date_attr(name, opts = {})
           opts[:dynamodb_type] = "S"
           attr(name, Attributes::DateMarshaler, opts)
@@ -188,6 +218,11 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is false.
         def datetime_attr(name, opts = {})
           opts[:dynamodb_type] = "S"
           attr(name, Attributes::DateTimeMarshaler, opts)
@@ -223,8 +258,14 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is true.
         def list_attr(name, opts = {})
           opts[:dynamodb_type] = "L"
+          opts[:mutation_tracking] = true if opts[:mutation_tracking].nil?
           attr(name, Attributes::ListMarshaler, opts)
         end
 
@@ -258,8 +299,14 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is true.
         def map_attr(name, opts = {})
           opts[:dynamodb_type] = "M"
+          opts[:mutation_tracking] = true if opts[:mutation_tracking].nil?
           attr(name, Attributes::MapMarshaler, opts)
         end
 
@@ -280,8 +327,14 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is true.
         def string_set_attr(name, opts = {})
           opts[:dynamodb_type] = "SS"
+          opts[:mutation_tracking] = true if opts[:mutation_tracking].nil?
           attr(name, Attributes::StringSetMarshaler, opts)
         end
 
@@ -302,8 +355,14 @@ module Aws
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
         #   the range key for the table.
+        # @option options [Boolean] :mutation_tracking Optional attribute used to
+        #   indicate if mutations to values should be explicitly tracked when
+        #   determining if a value is "dirty". Important for collection types
+        #   which are often primarily modified by mutation of a single object
+        #   reference. By default, is true.
         def numeric_set_attr(name, opts = {})
           opts[:dynamodb_type] = "NS"
+          opts[:mutation_tracking] = true if opts[:mutation_tracking].nil?
           attr(name, Attributes::NumericSetMarshaler, opts)
         end
 
@@ -331,6 +390,13 @@ module Aws
         #   name symbols associated with them.
         def keys
           @keys
+        end
+
+        # @param [Symbol] attr_sym The symbolized name of the attribute.
+        # @return [Boolean] true if object mutations are tracked for dirty
+        #   checking of that attribute, false if mutations are not tracked.
+        def track_mutations?(attr_sym)
+          mutation_tracking_enabled? && attributes[attr_sym].track_mutations?
         end
 
         private

--- a/lib/aws-record/record/dirty_tracking.rb
+++ b/lib/aws-record/record/dirty_tracking.rb
@@ -45,11 +45,7 @@ module Aws
       # @param [String, Symbol] name The name of the attribute to to check for dirty changes.
       # @return [Boolean] +true+ if the specified attribute has any dirty changes, +false+ otherwise.
       def attribute_dirty?(name)
-        if @mutation_copies.has_key?(name)
-          @data[name] != @mutation_copies[name]
-        else
-          @dirty_data.has_key?(name)
-        end
+        @dirty_data.has_key?(name) || _mutated?(name)
       end 
 
       # Returns the original value of the specified attribute.
@@ -291,6 +287,14 @@ module Aws
           @dirty_data.delete(name)
         else
           attribute_dirty!(name)
+        end
+      end
+
+      def _mutated?(name)
+        if @mutation_copies.has_key?(name)
+          @data[name] != @mutation_copies[name]
+        else
+          false
         end
       end
 

--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -21,17 +21,17 @@ module Aws
       end
 
       # Saves this instance of an item to Amazon DynamoDB. If this item is "new"
-      #  as defined by having new or altered key attributes, will attempt a
-      #  conditional
-      #  {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#put_item-instance_method Aws::DynamoDB::Client#put_item}
-      #  call, which will not overwrite an existing item. If the item only has
-      #  altered non-key attributes, will perform an
-      #  {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#update_item-instance_method Aws::DynamoDB::Client#update_item}
-      #  call. Uses this item instance's attributes in order to build the
-      #  request on your behalf.
+      # as defined by having new or altered key attributes, will attempt a
+      # conditional
+      # {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#put_item-instance_method Aws::DynamoDB::Client#put_item}
+      # call, which will not overwrite an existing item. If the item only has
+      # altered non-key attributes, will perform an
+      # {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#update_item-instance_method Aws::DynamoDB::Client#update_item}
+      # call. Uses this item instance's attributes in order to build the
+      # request on your behalf.
       #
       # You can use the +:force+ option to perform a simple put/overwrite
-      #  without conditional validation or update logic.
+      # without conditional validation or update logic.
       #
       # @param [Hash] opts
       # @option opts [Boolean] :force if true, will save as a put operation and
@@ -54,17 +54,17 @@ module Aws
       end
 
       # Saves this instance of an item to Amazon DynamoDB. If this item is "new"
-      #  as defined by having new or altered key attributes, will attempt a
-      #  conditional
-      #  {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#put_item-instance_method Aws::DynamoDB::Client#put_item}
-      #  call, which will not overwrite an existing item. If the item only has
-      #  altered non-key attributes, will perform an
-      #  {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#update_item-instance_method Aws::DynamoDB::Client#update_item}
-      #  call. Uses this item instance's attributes in order to build the
-      #  request on your behalf.
+      # as defined by having new or altered key attributes, will attempt a
+      # conditional
+      # {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#put_item-instance_method Aws::DynamoDB::Client#put_item}
+      # call, which will not overwrite an existing item. If the item only has
+      # altered non-key attributes, will perform an
+      # {http://docs.aws.amazon.com/sdkforruby/api/Aws/DynamoDB/Client.html#update_item-instance_method Aws::DynamoDB::Client#update_item}
+      # call. Uses this item instance's attributes in order to build the
+      # request on your behalf.
       #
       # You can use the +:force+ option to perform a simple put/overwrite
-      #  without conditional validation or update logic.
+      # without conditional validation or update logic.
       #
       # @param [Hash] opts
       # @option opts [Boolean] :force if true, will save as a put operation and

--- a/spec/aws-record/record/attribute_spec.rb
+++ b/spec/aws-record/record/attribute_spec.rb
@@ -17,10 +17,30 @@ module Aws
   module Record
     describe Attribute do
 
-      it 'can have a custom DB name' do
-        a = Attribute.new(:foo, database_attribute_name: "bar")
-        expect(a.name).to eq(:foo)
-        expect(a.database_name).to eq("bar")
+      context 'database_attribute_name' do
+        it 'can have a custom DB name' do
+          a = Attribute.new(:foo, database_attribute_name: "bar")
+          expect(a.name).to eq(:foo)
+          expect(a.database_name).to eq("bar")
+        end
+
+        it 'uses the attribute name by default for the DB name' do
+          a = Attribute.new(:foo)
+          expect(a.name).to eq(:foo)
+          expect(a.database_name).to eq("foo")
+        end
+      end
+
+      context 'mutation_tracking' do
+        it 'does not track mutations by default' do
+          a = Attribute.new(:foo)
+          expect(a.track_mutations?).to eq(false)
+        end
+
+        it 'has an option to track mutations' do
+          a = Attribute.new(:foo, mutation_tracking: true)
+          expect(a.track_mutations?).to eq(true)
+        end
       end
 
     end

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -152,6 +152,33 @@ module Aws
         end
       end
 
+      context "Mutation Tracking" do
+        it 'should do mutation tracking for list attributes' do
+          klass.list_attr(:mt)
+          expect(klass.attributes[:mt].track_mutations?).to be_truthy
+        end
+
+        it 'should do mutation tracking for map attributes' do
+          klass.map_attr(:mt)
+          expect(klass.attributes[:mt].track_mutations?).to be_truthy
+        end
+
+        it 'should do mutation tracking for numeric set attributes' do
+          klass.numeric_set_attr(:mt)
+          expect(klass.attributes[:mt].track_mutations?).to be_truthy
+        end
+
+        it 'should do mutation tracking for string set attributes' do
+          klass.string_set_attr(:mt)
+          expect(klass.attributes[:mt].track_mutations?).to be_truthy
+        end
+
+        it 'can turn off mutation tracking at the attribute level' do
+          klass.list_attr(:mt, mutation_tracking: false)
+          expect(klass.attributes[:mt].track_mutations?).to be_falsy
+        end
+      end
+
     end
   end
 end

--- a/spec/aws-record/record_spec.rb
+++ b/spec/aws-record/record_spec.rb
@@ -127,5 +127,26 @@ module Aws
       end
 
     end
+
+    describe "#track_mutations" do
+      let(:model) {
+        Class.new do
+          include(Aws::Record)
+          set_table_name("TestTable")
+          string_attr(:uuid, hash_key: true)
+          attr(:mt, Aws::Record::Attributes::StringMarshaler, mutation_tracking: true)
+        end
+      }
+
+      it 'supports mutation tracking for the appropriate attributes by default' do
+        expect(model.track_mutations?(:mt)).to be_truthy
+      end
+
+      it 'can turn off mutation tracking globally for a model' do
+        model.disable_mutation_tracking
+        expect(model.track_mutations?(:mt)).to be_falsy
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Adds mutation tracking of attributes in `Aws::Record` models. This is turned on by default for the collection types: `:list_attr`, `:map_attr`, `:string_set_attr`, and `:numeric_set_attr`. But can be enabled/disabled for individual attributes, and disabled if desired at the model level.