### PR TITLE
Persistence Refactors for Nil Handling

### DIFF
--- a/features/items/item_updates.feature
+++ b/features/items/item_updates.feature
@@ -220,3 +220,42 @@ Feature: Amazon DynamoDB Item Updates
         "z": "bar"
       }
       """
+
+@wip
+Scenario: Updating an Object for Attribute Removal
+    Given an aws-record model with data:
+      """
+      [
+        { "method": "string_attr", "name": "hk", "hash_key": true },
+        { "method": "string_attr", "name": "rk", "range_key": true },
+        { "method": "string_attr", "name": "x" },
+        { "method": "string_attr", "name": "y" },
+        { "method": "string_attr", "name": "z" }
+      ]
+      """
+    When we call the 'update' class method with parameter data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample",
+        "y": "foo",
+        "z": null
+      }
+      """
+    And we call the 'find' class method with parameter data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample"
+      }
+      """
+    Then we should receive an aws-record item with attribute data:
+      """
+      {
+        "hk": "sample",
+        "rk": "sample",
+        "x": "x",
+        "y": "foo",
+        "z": null
+      }
+      """

--- a/features/items/item_updates.feature
+++ b/features/items/item_updates.feature
@@ -221,7 +221,6 @@ Feature: Amazon DynamoDB Item Updates
       }
       """
 
-@wip
 Scenario: Updating an Object for Attribute Removal
     Given an aws-record model with data:
       """

--- a/features/items/item_updates.feature
+++ b/features/items/item_updates.feature
@@ -241,20 +241,18 @@ Scenario: Updating an Object for Attribute Removal
         "z": null
       }
       """
-    And we call the 'find' class method with parameter data:
+    Then the DynamoDB table should have exactly the following item attributes:
       """
       {
-        "hk": "sample",
-        "rk": "sample"
-      }
-      """
-    Then we should receive an aws-record item with attribute data:
-      """
-      {
-        "hk": "sample",
-        "rk": "sample",
-        "x": "x",
-        "y": "foo",
-        "z": null
+        "key": {
+          "hk": "sample",
+          "rk": "sample"
+        },
+        "item": {
+          "hk": "sample",
+          "rk": "sample",
+          "x": "x",
+          "y": "foo"
+        }
       }
       """

--- a/features/step_definitions.rb
+++ b/features/step_definitions.rb
@@ -134,3 +134,19 @@ Given(/^an aws\-record model with definition:$/) do |string|
   @model.class_eval(string)
 end
 
+Then(/^the DynamoDB table should have exactly the following item attributes:$/) do |string|
+  data = JSON.parse(string)
+  key = {}
+  data["key"].each do |row|
+    attribute, value = row
+    key[attribute] = value
+  end
+  resp = @client.get_item(
+    table_name: @table_name,
+    key: key
+  )
+  expect(resp.item.keys.sort).to eq(data["item"].keys.sort)
+  data["item"].each do |k,v|
+    expect(resp.item[k]).to eq(v)
+  end
+end

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -88,10 +88,14 @@ module Aws
         #   secondary index, but most convenience methods for setting attributes
         #   will provide this.
         # @option options [Boolean] :mutation_tracking Optional attribute used to
-        #   indicate if mutations to values should be explicitly tracked when
+        #   indicate whether mutations to values should be explicitly tracked when
         #   determining if a value is "dirty". Important for collection types
         #   which are often primarily modified by mutation of a single object
         #   reference. By default, is false.
+        # @option options [Boolean] :persist_nil Optional attribute used to
+        #   indicate whether nil values should be persisted. If true, explicitly
+        #   set nil values will be saved to DynamoDB as a "null" type. If false,
+        #   nil values will be ignored and not persisted. By default, is false.
         # @option opts [Boolean] :hash_key Set to true if this attribute is
         #   the hash key for the table.
         # @option opts [Boolean] :range_key Set to true if this attribute is
@@ -128,6 +132,10 @@ module Aws
         #   determining if a value is "dirty". Important for collection types
         #   which are often primarily modified by mutation of a single object
         #   reference. By default, is false.
+        # @option options [Boolean] :persist_nil Optional attribute used to
+        #   indicate whether nil values should be persisted. If true, explicitly
+        #   set nil values will be saved to DynamoDB as a "null" type. If false,
+        #   nil values will be ignored and not persisted. By default, is false.
         def string_attr(name, opts = {})
           opts[:dynamodb_type] = "S"
           attr(name, Attributes::StringMarshaler, opts)
@@ -147,6 +155,10 @@ module Aws
         #   determining if a value is "dirty". Important for collection types
         #   which are often primarily modified by mutation of a single object
         #   reference. By default, is false.
+        # @option options [Boolean] :persist_nil Optional attribute used to
+        #   indicate whether nil values should be persisted. If true, explicitly
+        #   set nil values will be saved to DynamoDB as a "null" type. If false,
+        #   nil values will be ignored and not persisted. By default, is false.
         def boolean_attr(name, opts = {})
           opts[:dynamodb_type] = "BOOL"
           attr(name, Attributes::BooleanMarshaler, opts)
@@ -166,6 +178,10 @@ module Aws
         #   determining if a value is "dirty". Important for collection types
         #   which are often primarily modified by mutation of a single object
         #   reference. By default, is false.
+        # @option options [Boolean] :persist_nil Optional attribute used to
+        #   indicate whether nil values should be persisted. If true, explicitly
+        #   set nil values will be saved to DynamoDB as a "null" type. If false,
+        #   nil values will be ignored and not persisted. By default, is false.
         def integer_attr(name, opts = {})
           opts[:dynamodb_type] = "N"
           attr(name, Attributes::IntegerMarshaler, opts)
@@ -185,6 +201,10 @@ module Aws
         #   determining if a value is "dirty". Important for collection types
         #   which are often primarily modified by mutation of a single object
         #   reference. By default, is false.
+        # @option options [Boolean] :persist_nil Optional attribute used to
+        #   indicate whether nil values should be persisted. If true, explicitly
+        #   set nil values will be saved to DynamoDB as a "null" type. If false,
+        #   nil values will be ignored and not persisted. By default, is false.
         def float_attr(name, opts = {})
           opts[:dynamodb_type] = "N"
           attr(name, Attributes::FloatMarshaler, opts)
@@ -204,6 +224,10 @@ module Aws
         #   determining if a value is "dirty". Important for collection types
         #   which are often primarily modified by mutation of a single object
         #   reference. By default, is false.
+        # @option options [Boolean] :persist_nil Optional attribute used to
+        #   indicate whether nil values should be persisted. If true, explicitly
+        #   set nil values will be saved to DynamoDB as a "null" type. If false,
+        #   nil values will be ignored and not persisted. By default, is false.
         def date_attr(name, opts = {})
           opts[:dynamodb_type] = "S"
           attr(name, Attributes::DateMarshaler, opts)
@@ -223,6 +247,10 @@ module Aws
         #   determining if a value is "dirty". Important for collection types
         #   which are often primarily modified by mutation of a single object
         #   reference. By default, is false.
+        # @option options [Boolean] :persist_nil Optional attribute used to
+        #   indicate whether nil values should be persisted. If true, explicitly
+        #   set nil values will be saved to DynamoDB as a "null" type. If false,
+        #   nil values will be ignored and not persisted. By default, is false.
         def datetime_attr(name, opts = {})
           opts[:dynamodb_type] = "S"
           attr(name, Attributes::DateTimeMarshaler, opts)


### PR DESCRIPTION
This change covers a few different areas related to our persistence
logic:

* All calls to `Aws::DynamoDB::Client#update_item` now use update
  expressions exclusively.
* `nil` values will not be persisted in any case unless `:persist_nil`
  is set for the attribute(s) in question. There are also
  collection-specific parameters to persist nil as empty collections in
  some cases, which are now honored.
* Update calls will now use the `REMOVE` expression when the value is
  `nil` and `:persist_nil` is `false` for the attribute.